### PR TITLE
add dist_ffi Go implementation

### DIFF
--- a/rpc/dist_ffi.go
+++ b/rpc/dist_ffi.go
@@ -1,0 +1,79 @@
+package rpc
+
+import (
+	"github.com/tchajed/marshal"
+	"io"
+	"net"
+)
+
+/// Sender
+type Sender struct {
+    conn net.Conn
+}
+
+func MakeSender(host string) *Sender {
+	// FIXME: cache "conn" in some global map to make connections live longer
+	conn, _ := net.Dial("tcp", host)
+	// We ignore errors (all packets are just silently dropped)
+	return &Sender { conn }
+}
+
+func Send(send *Sender, data []byte) {
+	e := marshal.NewEnc(8 + uint64(len(data)))
+	e.PutInt(uint64(len(data)))
+	e.PutBytes(data)
+	reqData := e.Finish()
+	send.conn.Write(reqData) // one atomic write for the entire thing!
+}
+
+/// Receiver
+type Receiver struct {
+    c chan []byte
+}
+
+func receiveOnSocket(conn net.Conn, c chan []byte) {
+	for {
+		// reply format: [dataLen] ++ data
+		header := make([]byte, 8)
+		_, err := io.ReadFull(conn, header)
+		if err != nil {
+			return
+		}
+		d := marshal.NewDec(header)
+		dataLen := d.GetInt()
+
+		data := make([]byte, dataLen)
+		_, err2 := io.ReadFull(conn, data)
+		if err2 != nil {
+			return
+		}
+		c <- data
+	}
+}
+
+func listenOnSocket(l net.Listener, c chan []byte) {
+	for {
+		conn, err := l.Accept()
+		if err != nil {
+			return
+		}
+		// Spawn new thread receiving data on this connection
+		go receiveOnSocket(conn, c)
+	}
+}
+
+func MakeReceiver(host string) *Receiver {
+	c := make(chan []byte)
+	l, err := net.Listen("tcp", host)
+	if err != nil {
+		return &Receiver { c }
+	}
+	// Keep accepting new connections in background thread
+	go listenOnSocket(l, c)
+	return &Receiver { c }
+}
+
+// This will never actually return NULL, but as long as clients and proofs do not rely on this that is okay.
+func Receive(recv *Receiver) []byte {
+	return <-recv.c
+}

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -2,19 +2,15 @@ package rpc
 
 import (
 	"github.com/tchajed/marshal"
-	"io"
-	"net"
 	"sync"
-	"fmt"
 )
 
-type RPCServerWorker struct {
+type RPCServer struct {
 	handlers map[uint64]func([]byte, *[]byte)
-	epoller  *Epoller
-	state    map[int]reqState
 }
 
-func (srv *RPCServerWorker) rpcHandle(c net.Conn, rpcid uint64, seqno uint64, data []byte) {
+func (srv *RPCServer) rpcHandle(rpcid uint64, seqno uint64, senderHost []byte, data []byte) {
+	sender := MakeSender(string(senderHost))
 	/*
 	start := time.Now()
 	defer func() {
@@ -29,117 +25,31 @@ func (srv *RPCServerWorker) rpcHandle(c net.Conn, rpcid uint64, seqno uint64, da
 	e.PutInt(seqno)
 	e.PutInt(uint64(len(replyData)))
 	e.PutBytes(replyData)
-	_, err := c.Write(e.Finish()) // TODO: contention? should we buffer these in userspace too?
-	if err != nil {
-		panic(err)
-		// client might close the connection by the time that we finish
-		// processing their request
-		// panic(err)
+	Send(sender, e.Finish()) // TODO: contention? should we buffer these in userspace too?
+}
+
+func MakeRPCServer(handlers map[uint64]func([]byte, *[]byte)) *RPCServer {
+	return &RPCServer{handlers: handlers}
+}
+
+func (srv *RPCServer) Serve(host string, numWorkers int) {
+	recv := MakeReceiver(host)
+	for i := 0; i < numWorkers; i++ {
+		go srv.readThread(recv)
 	}
 }
 
-type reqState struct {
-	data []byte
-	off  uint64
-}
-
-type RPCServer struct {
-	handlers map[uint64]func([]byte, *[]byte)
-	workerEpollers []*Epoller
-}
-
-func MakeRPCServer(handlers map[uint64]func([]byte, *[]byte), numWorkers uint64) *RPCServer {
-	epollers := make([]*Epoller, numWorkers)
-	for i := uint64(0); i < numWorkers; i++ {
-		epollers[i] = MakeEpoller()
-	}
-	return &RPCServer{handlers: handlers, workerEpollers: epollers}
-}
-
-func (srv *RPCServer) Serve(port string) {
-	go srv.acceptThread(port)
-	for i := 0; i < len(srv.workerEpollers); i++ {
-		s := &RPCServerWorker{handlers:srv.handlers, epoller:srv.workerEpollers[i], state:make(map[int]reqState)}
-		go s.readThread()
-	}
-}
-
-func (srv *RPCServer) acceptThread(port string) {
-	l, err := net.Listen("tcp", port)
-	if err != nil {
-		panic(err)
-	}
-	defer l.Close()
-
-	for i := 0; ; i++ {
-		c, err := l.Accept()
-		if err != nil {
-			panic(err)
-		}
-		// fmt.Printf("Adding to %d\n", i % len(srv.workerEpollers))
-		srv.workerEpollers[i % len(srv.workerEpollers) ].Add(c) // FIXME: concurrent map access
-	}
-}
-
-const headerSize = 8 * 3
-
-func (srv *RPCServerWorker) readThread() {
-	// fmt.Println("Worker thread")
+func (srv *RPCServer) readThread(recv *Receiver) {
 	for {
-		es := srv.epoller.Wait()
-		for _, e := range es {
-			// fmt.Println("Polled")
-			f := int(e.Fd)
-			c := srv.epoller.Conns[f]
-			s, ok := srv.state[f]
-			if !ok {
-				s = reqState{data: nil, off: 0}
-			}
-			if len(s.data) == 0 {
-				s.data = make([]byte, 1024)
-				s.off = 0
-			}
-
-			// fmt.Printf("%+v\n", s)
-			if s.off >= uint64(len(s.data)) {
-				fmt.Println(s)
-			}
-			if len(s.data) == 0 {
-				fmt.Println(s)
-			}
-			n, err := c.Read(s.data[s.off:])
-			if err != nil {
-				srv.epoller.Remove(c)
-				delete(srv.state, f)
-			}
-
-			if s.off < headerSize && headerSize <= (uint64(n)+s.off) {
-				// get length of args data, and grow s.data if needed
-				d := marshal.NewDec(s.data[8*2 : 8*3])
-				argsLen := d.GetInt()
-				// fmt.Println(argsLen)
-				if argsLen > uint64((len(s.data) - 8*3)) {
-					extraSize := argsLen - uint64((len(s.data) - 8*3))
-					s.data = append(s.data, make([]byte, extraSize)...)
-				} else {
-					s.data = s.data[:headerSize+argsLen]
-					// fmt.Printf("trim: %+v\n", s)
-				}
-			}
-			s.off = s.off + uint64(n)
-			if s.off == uint64(len(s.data)) {
-				// got a full request
-				d := marshal.NewDec(s.data)
-				rpcid := d.GetInt()
-				seqno := d.GetInt()
-				d.GetInt() // skip
-				reqData := s.data[headerSize:]
-				go srv.rpcHandle(c, rpcid, seqno, reqData)
-				s = reqState{data: nil, off: 0}
-			}
-
-			srv.state[f] = s
-		}
+		data := Receive(recv)
+		d := marshal.NewDec(data)
+		rpcid := d.GetInt()
+		seqno := d.GetInt()
+		senderLen := d.GetInt()
+		sender := d.GetBytes(senderLen)
+		reqLen := d.GetInt()
+		req := d.GetBytes(reqLen)
+		go srv.rpcHandle(rpcid, seqno, sender, req)
 	}
 }
 
@@ -151,32 +61,22 @@ type callback struct {
 
 type RPCClient struct {
 	mu   *sync.Mutex
-	conn net.Conn
+	send *Sender // for requests
+	me string // host for responses
 	seq  uint64 // next fresh sequence number
 
 	pending map[uint64]*callback
 }
 
 func (cl *RPCClient) replyThread() {
+	recv := MakeReceiver(cl.me)
 	for {
-		// reply format: [seqno, dataLen] ++ data
-		headerData := make([]byte, 8*2)
-		_, err := io.ReadFull(cl.conn, headerData)
-		if err != nil {
-			panic(err)
-		}
-		// fmt.Printf("Client read header %+v\n", headerData)
-
-		d := marshal.NewDec(headerData)
+		data := Receive(recv)
+		d := marshal.NewDec(data)
 		seqno := d.GetInt()
+		// TODO: Can we just "read the rest of the bytes"?
 		replyLen := d.GetInt()
-
-		reply := make([]byte, replyLen)
-		_, err = io.ReadFull(cl.conn, reply)
-		// fmt.Printf("Client read %+v\n", reply)
-		if err != nil {
-			panic(err)
-		}
+		reply := d.GetBytes(replyLen)
 
 		cl.mu.Lock()
 		cb, ok := cl.pending[seqno]
@@ -190,14 +90,10 @@ func (cl *RPCClient) replyThread() {
 	}
 }
 
-func MakeRPCClient(host string) *RPCClient {
+func MakeRPCClient(host string, me string) *RPCClient {
 	cl := new(RPCClient)
-	conn, err := net.Dial("tcp", host)
-	if err != nil {
-		panic(err)
-	}
-
-	cl.conn = conn
+	cl.send = MakeSender(host)
+	cl.me = me
 	cl.mu = new(sync.Mutex)
 	cl.seq = 1
 	cl.pending = make(map[uint64]*callback)
@@ -214,19 +110,20 @@ func (cl *RPCClient) Call(rpcid uint64, args []byte, reply *[]byte) bool {
 	cl.seq = cl.seq + 1
 	cl.pending[seqno] = &cb
 	cl.mu.Unlock()
+	me := []byte(cl.me)
 
-	e := marshal.NewEnc(8 + 8 + 8 + uint64(len(args)))
+	e := marshal.NewEnc(8 + 8 + (8 + uint64(len(me))) + (8 + uint64(len(args))))
 	e.PutInt(rpcid)
 	e.PutInt(seqno)
+	// TODO: would be nice if the marshal lib had support for len+data pairs...
+	e.PutInt(uint64(len(me)))
+	e.PutBytes(me)
 	e.PutInt(uint64(len(args)))
 	e.PutBytes(args)
 	reqData := e.Finish()
 	// fmt.Fprintf(os.Stderr, "%+v\n", reqData)
 
-	_, err := cl.conn.Write(reqData)
-	if err != nil {
-		panic(err)
-	}
+	Send(cl.send, reqData)
 
 	// wait for reply
 	cl.mu.Lock()


### PR DESCRIPTION
This is intended to match the "exports" of https://github.com/mit-pdos/perennial/blob/master/src/goose_lang/ffi/dist_ffi.v, but I don't know how to actually wire these things up.

I am not sure what the best idiom for "opaque types" is in Go; if we make `*Sender`/`*Receiver` itself just a type alias then will Goose be able to use that type alias in a struct field? The current API exposes that these are pointers so Goose knows their size, but clients should *not* ever work with the pointed-to types directly. (In verified code this will be impossible anyway since the values of type`*Sender` will *not* actually be locations. They will be "external"/FFI values instead.)